### PR TITLE
Fixed Error: Could not find the correct Provider<SliderModel>

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,16 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_carousel_intro/flutter_carousel_intro.dart';
-import 'package:flutter_carousel_intro/slider_model.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:provider/provider.dart';
 
 void main() {
-  runApp(
-    ChangeNotifierProvider<SliderModel>(
-      create: (_) => SliderModel(),
-      child: const MyApp(),
-    ),
-  );
+  runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -163,7 +163,7 @@ packages:
     source: hosted
     version: "5.1.0"
   provider:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: provider
       sha256: e1e7413d70444ea3096815a60fe5da1b11bda8a9dc4769252cc82c53536f8bcc

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -39,7 +39,6 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  provider: ^6.0.4
 
 dev_dependencies:
   flutter_test:

--- a/lib/flutter_carousel_intro.dart
+++ b/lib/flutter_carousel_intro.dart
@@ -1,8 +1,6 @@
 import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-
 import 'dots.dart';
 import 'slider_model.dart';
 
@@ -46,33 +44,95 @@ class FlutterCarouselIntro extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final SliderModel slideModelController = context.watch<SliderModel>();
     return ChangeNotifierProvider<SliderModel>(
       create: (_) => SliderModel(),
-      child: SafeArea(
-        child: Center(
-          child: Builder(builder: (context) {
-            slideModelController
-              ..primaryColor = primaryColor
-              ..secondaryColor = secondaryColor
-              ..primaryBullet = primaryBullet
-              ..secondaryBullet = secondaryBullet;
-            return _CreateStructureSlides(
-              pointsAbove: pointsAbove,
-              slides: slides,
-              animatedRotateX: animatedRotateX,
-              animatedRotateZ: animatedRotateZ,
-              scale: scale,
-              dotsCurve: dotsCurve,
-              animatedOpacity: animatedOpacity,
-              physics: physics,
-              height: dotsContainerHeight,
-              width: dotsContainerWidth,
-              pageViewController: controller,
-              scrollDirection: scrollDirection,
-            );
-          }),
-        ),
+      child: _FlutterCarousel(
+        primaryColor: primaryColor,
+        secondaryColor: secondaryColor,
+        primaryBullet: primaryBullet,
+        secondaryBullet: secondaryBullet,
+        pointsAbove: pointsAbove,
+        slides: slides,
+        animatedRotateX: animatedRotateX,
+        animatedRotateZ: animatedRotateZ,
+        scale: scale,
+        dotsCurve: dotsCurve,
+        animatedOpacity: animatedOpacity,
+        physics: physics,
+        dotsContainerHeight: dotsContainerHeight,
+        dotsContainerWidth: dotsContainerWidth,
+        controller: controller,
+        scrollDirection: scrollDirection,
+      ),
+    );
+  }
+}
+
+class _FlutterCarousel extends StatelessWidget {
+  const _FlutterCarousel({
+    Key? key,
+    required this.primaryColor,
+    required this.secondaryColor,
+    required this.primaryBullet,
+    required this.secondaryBullet,
+    required this.pointsAbove,
+    required this.slides,
+    required this.animatedRotateX,
+    required this.animatedRotateZ,
+    required this.scale,
+    required this.dotsCurve,
+    required this.animatedOpacity,
+    required this.physics,
+    required this.dotsContainerHeight,
+    required this.dotsContainerWidth,
+    required this.controller,
+    required this.scrollDirection,
+  }) : super(key: key);
+
+  final Color primaryColor;
+  final Color secondaryColor;
+  final double primaryBullet;
+  final double secondaryBullet;
+  final bool pointsAbove;
+  final List<Widget> slides;
+  final bool animatedRotateX;
+  final bool animatedRotateZ;
+  final bool scale;
+  final Curve dotsCurve;
+  final bool animatedOpacity;
+  final ScrollPhysics? physics;
+  final double? dotsContainerHeight;
+  final double? dotsContainerWidth;
+  final PageController? controller;
+  final Axis? scrollDirection;
+
+  @override
+  Widget build(BuildContext context) {
+    final slideModelController = context.watch<SliderModel>();
+
+    return SafeArea(
+      child: Center(
+        child: Builder(builder: (context) {
+          slideModelController
+            ..primaryColor = primaryColor
+            ..secondaryColor = secondaryColor
+            ..primaryBullet = primaryBullet
+            ..secondaryBullet = secondaryBullet;
+          return _CreateStructureSlides(
+            pointsAbove: pointsAbove,
+            slides: slides,
+            animatedRotateX: animatedRotateX,
+            animatedRotateZ: animatedRotateZ,
+            scale: scale,
+            dotsCurve: dotsCurve,
+            animatedOpacity: animatedOpacity,
+            physics: physics,
+            height: dotsContainerHeight,
+            width: dotsContainerWidth,
+            pageViewController: controller,
+            scrollDirection: scrollDirection,
+          );
+        }),
       ),
     );
   }


### PR DESCRIPTION
Fixed issue https://github.com/eliezerantonio/flutter_carousel_intro/issues/19 

The previous implementation was trying to read the provider before it was initialised.
To fix that, I moved `final slideModelController = context.watch<SliderModel>();` to another file.
This way the ChangeNotifierProvider<SliverModel> is first created and only after that we listen the provider changes.