### PR TITLE
Display Slide indicators based on scroll direction

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,6 +44,8 @@ class MySlideShow extends StatelessWidget {
       animatedRotateX: false,
       animatedRotateZ: true,
       scale: true,
+      autoPlay: false,
+      autoPlaySlideDuration: const Duration(seconds: 2),
       animatedOpacity: true,
       primaryBullet: 20,
       secondaryBullet: 12,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -43,7 +43,6 @@ class MySlideShow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return FlutterCarouselIntro(
-      pointsAbove: false,
       animatedRotateX: false,
       animatedRotateZ: true,
       scale: true,

--- a/lib/dot.dart
+++ b/lib/dot.dart
@@ -10,9 +10,12 @@ class Dot extends StatelessWidget {
     Key? key,
     required this.index,
     required this.dotsCurve,
+    this.scrollDirection = Axis.horizontal,
   }) : super(key: key);
   final int index;
   final Curve dotsCurve;
+  final Axis scrollDirection;
+
   @override
   Widget build(BuildContext context) {
     final slideShowModel = context.watch<SliderModel>();
@@ -27,22 +30,22 @@ class Dot extends StatelessWidget {
 
     double dotWidth = dotSize * sin(pi / 4);
     double dotHeight = dotSize * sin(pi / 4);
-    return Center(
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 500),
-        width: dotWidth,
-        alignment: Alignment.center,
-        margin: const EdgeInsets.symmetric(horizontal: 5),
-        height: dotHeight,
-        transformAlignment: Alignment.center,
-        transform: Matrix4.identity()..rotateZ(value * 2),
-        curve: dotsCurve,
-        decoration: BoxDecoration(
-          color: condition
-              ? slideShowModel.primaryColor
-              : slideShowModel.secondaryColor,
-          shape: BoxShape.circle,
-        ),
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 500),
+      width: dotWidth,
+      alignment: Alignment.center,
+      margin: scrollDirection == Axis.horizontal
+          ? const EdgeInsets.all(5)
+          : const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+      height: dotHeight,
+      transformAlignment: Alignment.center,
+      transform: Matrix4.identity()..rotateZ(value * 2),
+      curve: dotsCurve,
+      decoration: BoxDecoration(
+        color: condition
+            ? slideShowModel.primaryColor
+            : slideShowModel.secondaryColor,
+        shape: BoxShape.circle,
       ),
     );
   }

--- a/lib/dots.dart
+++ b/lib/dots.dart
@@ -1,29 +1,41 @@
 import 'package:flutter/material.dart';
-
 import 'dot.dart';
 
 class Dots extends StatelessWidget {
-  const Dots(
-      {Key? key,
-      required this.totalSlides,
-      required this.dotsCurve,
-      this.height,
-      this.width})
-      : super(key: key);
+  const Dots({
+    Key? key,
+    required this.totalSlides,
+    required this.dotsCurve,
+    required this.scrollDirection,
+    this.height,
+    this.width,
+  }) : super(key: key);
   final int totalSlides;
   final Curve dotsCurve;
   final double? height;
   final double? width;
+  final Axis scrollDirection;
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: width ?? double.infinity,
-      height: height ?? 70,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: List.generate(
-            totalSlides, (index) => Dot(index: index, dotsCurve: dotsCurve)),
-      ),
+      width: width,
+      height: scrollDirection == Axis.horizontal ? 70 : null,
+      child: scrollDirection == Axis.horizontal
+          ? Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: List.generate(totalSlides,
+                  (index) => Dot(index: index, dotsCurve: dotsCurve)),
+            )
+          : Column(
+              mainAxisSize: MainAxisSize.min,
+              children: List.generate(
+                  totalSlides,
+                  (index) => Dot(
+                        index: index,
+                        dotsCurve: dotsCurve,
+                        scrollDirection: scrollDirection,
+                      )),
+            ),
     );
   }
 }

--- a/lib/flutter_carousel_intro.dart
+++ b/lib/flutter_carousel_intro.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_carousel_intro/utils/enums.dart';
@@ -11,6 +12,8 @@ class FlutterCarouselIntro extends StatelessWidget {
   final bool animatedRotateZ;
   final bool animatedOpacity;
   final bool scale;
+  final bool autoPlay;
+  final Duration? autoPlaySlideDuration;
   final Color primaryColor;
   final Color secondaryColor;
   final double primaryBullet;
@@ -29,6 +32,8 @@ class FlutterCarouselIntro extends StatelessWidget {
     this.animatedRotateX = false,
     this.animatedRotateZ = false,
     this.animatedOpacity = false,
+    this.autoPlay = false,
+    this.autoPlaySlideDuration,
     this.scale = false,
     this.dotsCurve = Curves.linear,
     this.primaryColor = Colors.blue,
@@ -64,6 +69,9 @@ class FlutterCarouselIntro extends StatelessWidget {
         controller: controller,
         scrollDirection: scrollDirection,
         indicatorAlign: indicatorAlign,
+        autoPlay: autoPlay,
+        autoPlaySlideDuration:
+            autoPlaySlideDuration ?? const Duration(milliseconds: 500),
       ),
     );
   }
@@ -88,6 +96,8 @@ class _FlutterCarousel extends StatelessWidget {
     required this.controller,
     required this.scrollDirection,
     required this.indicatorAlign,
+    required this.autoPlay,
+    required this.autoPlaySlideDuration,
   }) : super(key: key);
 
   final Color primaryColor;
@@ -106,6 +116,8 @@ class _FlutterCarousel extends StatelessWidget {
   final PageController? controller;
   final Axis scrollDirection;
   final IndicatorAlign? indicatorAlign;
+  final bool autoPlay;
+  final Duration autoPlaySlideDuration;
 
   @override
   Widget build(BuildContext context) {
@@ -132,6 +144,8 @@ class _FlutterCarousel extends StatelessWidget {
             pageViewController: controller,
             scrollDirection: scrollDirection,
             indicatorAlign: indicatorAlign,
+            autoPlay: autoPlay,
+            autoPlaySlideDuration: autoPlaySlideDuration,
           );
         }),
       ),
@@ -153,6 +167,8 @@ class _CreateStructureSlides extends StatelessWidget {
     required this.scrollDirection,
     required this.indicatorAlign,
     required this.pageViewController,
+    required this.autoPlay,
+    required this.autoPlaySlideDuration,
   });
 
   final List<Widget> slides;
@@ -167,6 +183,8 @@ class _CreateStructureSlides extends StatelessWidget {
   final Axis scrollDirection;
   final IndicatorAlign? indicatorAlign;
   final PageController? pageViewController;
+  final bool autoPlay;
+  final Duration autoPlaySlideDuration;
 
   @override
   Widget build(BuildContext context) {
@@ -189,6 +207,8 @@ class _CreateStructureSlides extends StatelessWidget {
           physics,
           pageViewController,
           scrollDirection: scrollDirection,
+          autoPlay: autoPlay,
+          autoPlaySlideDuration: autoPlaySlideDuration,
         ),
       ],
     );
@@ -223,6 +243,8 @@ class _Slides extends StatefulWidget {
   final ScrollPhysics? physics;
   final PageController? pageViewController;
   final Axis scrollDirection;
+  final bool autoPlay;
+  final Duration autoPlaySlideDuration;
 
   const _Slides(
     this.slides,
@@ -233,6 +255,8 @@ class _Slides extends StatefulWidget {
     this.physics,
     this.pageViewController, {
     required this.scrollDirection,
+    required this.autoPlay,
+    required this.autoPlaySlideDuration,
   });
 
   @override
@@ -245,12 +269,28 @@ class _SlidesState extends State<_Slides> {
 
   @override
   void initState() {
+    if (widget.autoPlay) {
+      _playSlides();
+    }
+
     pageViewController.addListener(() {
       //update provider
-
       context.read<SliderModel>().currentPage = pageViewController.page!;
     });
     super.initState();
+  }
+
+  void _playSlides() {
+    Timer.periodic(widget.autoPlaySlideDuration, (timer) {
+      if ((pageViewController.page ?? 0) + 1 >= widget.slides.length) {
+        timer.cancel();
+      } else {
+        pageViewController.nextPage(
+          duration: const Duration(milliseconds: 400),
+          curve: Curves.ease,
+        );
+      }
+    });
   }
 
   @override

--- a/lib/flutter_carousel_intro.dart
+++ b/lib/flutter_carousel_intro.dart
@@ -1,12 +1,12 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
+import 'package:flutter_carousel_intro/utils/enums.dart';
 import 'package:provider/provider.dart';
 import 'dots.dart';
 import 'slider_model.dart';
 
 class FlutterCarouselIntro extends StatelessWidget {
   final List<Widget> slides;
-  final bool pointsAbove;
   final bool animatedRotateX;
   final bool animatedRotateZ;
   final bool animatedOpacity;
@@ -20,12 +20,12 @@ class FlutterCarouselIntro extends StatelessWidget {
   final double? dotsContainerHeight;
   final double? dotsContainerWidth;
   final PageController? controller;
-  final Axis? scrollDirection;
+  final Axis scrollDirection;
+  final IndicatorAlign? indicatorAlign;
 
   const FlutterCarouselIntro({
     Key? key,
     required this.slides,
-    this.pointsAbove = false,
     this.animatedRotateX = false,
     this.animatedRotateZ = false,
     this.animatedOpacity = false,
@@ -39,7 +39,8 @@ class FlutterCarouselIntro extends StatelessWidget {
     this.dotsContainerHeight,
     this.dotsContainerWidth,
     this.controller,
-    this.scrollDirection,
+    this.scrollDirection = Axis.horizontal,
+    this.indicatorAlign,
   }) : super(key: key);
 
   @override
@@ -51,7 +52,6 @@ class FlutterCarouselIntro extends StatelessWidget {
         secondaryColor: secondaryColor,
         primaryBullet: primaryBullet,
         secondaryBullet: secondaryBullet,
-        pointsAbove: pointsAbove,
         slides: slides,
         animatedRotateX: animatedRotateX,
         animatedRotateZ: animatedRotateZ,
@@ -63,6 +63,7 @@ class FlutterCarouselIntro extends StatelessWidget {
         dotsContainerWidth: dotsContainerWidth,
         controller: controller,
         scrollDirection: scrollDirection,
+        indicatorAlign: indicatorAlign,
       ),
     );
   }
@@ -75,7 +76,6 @@ class _FlutterCarousel extends StatelessWidget {
     required this.secondaryColor,
     required this.primaryBullet,
     required this.secondaryBullet,
-    required this.pointsAbove,
     required this.slides,
     required this.animatedRotateX,
     required this.animatedRotateZ,
@@ -87,13 +87,13 @@ class _FlutterCarousel extends StatelessWidget {
     required this.dotsContainerWidth,
     required this.controller,
     required this.scrollDirection,
+    required this.indicatorAlign,
   }) : super(key: key);
 
   final Color primaryColor;
   final Color secondaryColor;
   final double primaryBullet;
   final double secondaryBullet;
-  final bool pointsAbove;
   final List<Widget> slides;
   final bool animatedRotateX;
   final bool animatedRotateZ;
@@ -104,7 +104,8 @@ class _FlutterCarousel extends StatelessWidget {
   final double? dotsContainerHeight;
   final double? dotsContainerWidth;
   final PageController? controller;
-  final Axis? scrollDirection;
+  final Axis scrollDirection;
+  final IndicatorAlign? indicatorAlign;
 
   @override
   Widget build(BuildContext context) {
@@ -119,7 +120,6 @@ class _FlutterCarousel extends StatelessWidget {
             ..primaryBullet = primaryBullet
             ..secondaryBullet = secondaryBullet;
           return _CreateStructureSlides(
-            pointsAbove: pointsAbove,
             slides: slides,
             animatedRotateX: animatedRotateX,
             animatedRotateZ: animatedRotateZ,
@@ -131,6 +131,7 @@ class _FlutterCarousel extends StatelessWidget {
             width: dotsContainerWidth,
             pageViewController: controller,
             scrollDirection: scrollDirection,
+            indicatorAlign: indicatorAlign,
           );
         }),
       ),
@@ -140,7 +141,6 @@ class _FlutterCarousel extends StatelessWidget {
 
 class _CreateStructureSlides extends StatelessWidget {
   const _CreateStructureSlides({
-    required this.pointsAbove,
     required this.slides,
     required this.animatedRotateX,
     required this.animatedRotateZ,
@@ -150,11 +150,11 @@ class _CreateStructureSlides extends StatelessWidget {
     required this.physics,
     required this.height,
     required this.width,
-    this.scrollDirection,
+    required this.scrollDirection,
+    required this.indicatorAlign,
     required this.pageViewController,
   });
 
-  final bool pointsAbove;
   final List<Widget> slides;
   final Curve dotsCurve;
   final bool animatedRotateX;
@@ -164,29 +164,53 @@ class _CreateStructureSlides extends StatelessWidget {
   final ScrollPhysics? physics;
   final double? height;
   final double? width;
-  final Axis? scrollDirection;
+  final Axis scrollDirection;
+  final IndicatorAlign? indicatorAlign;
   final PageController? pageViewController;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    return Stack(
       children: [
-        if (pointsAbove) Dots(totalSlides: slides.length, dotsCurve: dotsCurve),
-        Expanded(
-          child: _Slides(
-            slides,
-            animatedRotateX,
-            animatedRotateZ,
-            scale,
-            animatedOpacity,
-            physics,
-            pageViewController,
+        Align(
+          alignment: _getAlignmentFromIndicatorAlign(indicatorAlign),
+          child: Dots(
+            totalSlides: slides.length,
+            dotsCurve: dotsCurve,
             scrollDirection: scrollDirection,
           ),
         ),
-        if (!pointsAbove) Dots(totalSlides: slides.length, dotsCurve: dotsCurve),
+        _Slides(
+          slides,
+          animatedRotateX,
+          animatedRotateZ,
+          scale,
+          animatedOpacity,
+          physics,
+          pageViewController,
+          scrollDirection: scrollDirection,
+        ),
       ],
     );
+  }
+
+  Alignment _getAlignmentFromIndicatorAlign(IndicatorAlign? align) {
+    switch (align) {
+      case IndicatorAlign.left:
+        return Alignment.centerLeft;
+      case IndicatorAlign.right:
+        return Alignment.centerRight;
+      case IndicatorAlign.bottom:
+        return Alignment.bottomCenter;
+      case IndicatorAlign.top:
+        return Alignment.topCenter;
+      default:
+        if (scrollDirection == Axis.horizontal) {
+          return Alignment.bottomCenter;
+        } else {
+          return Alignment.centerLeft;
+        }
+    }
   }
 }
 
@@ -198,7 +222,7 @@ class _Slides extends StatefulWidget {
   final bool scale;
   final ScrollPhysics? physics;
   final PageController? pageViewController;
-  final Axis? scrollDirection;
+  final Axis scrollDirection;
 
   const _Slides(
     this.slides,
@@ -208,7 +232,7 @@ class _Slides extends StatefulWidget {
     this.animatedOpacity,
     this.physics,
     this.pageViewController, {
-    this.scrollDirection,
+    required this.scrollDirection,
   });
 
   @override
@@ -216,7 +240,8 @@ class _Slides extends StatefulWidget {
 }
 
 class _SlidesState extends State<_Slides> {
-  late PageController pageViewController = widget.pageViewController ?? PageController();
+  late PageController pageViewController =
+      widget.pageViewController ?? PageController();
 
   @override
   void initState() {
@@ -240,7 +265,7 @@ class _SlidesState extends State<_Slides> {
     return PageView.builder(
       itemCount: widget.slides.length,
       controller: pageViewController,
-      scrollDirection: widget.scrollDirection ?? Axis.horizontal,
+      scrollDirection: widget.scrollDirection,
       physics: widget.physics ?? const BouncingScrollPhysics(),
       itemBuilder: (BuildContext context, int index) {
         final percent = 1 - (currentPage - index);

--- a/lib/flutter_carousel_intro.dart
+++ b/lib/flutter_carousel_intro.dart
@@ -329,10 +329,8 @@ class _SlidesState extends State<_Slides> {
                 ..scale(
                   widget.scale ? value : 1.0,
                   widget.scale ? value : 1.0,
-                )
-              // ,
-              ,
-              child: _Slide(
+                ),
+              child: _SlideItem(
                 widget.slides[index],
               ),
             ),
@@ -343,9 +341,9 @@ class _SlidesState extends State<_Slides> {
   }
 }
 
-class _Slide extends StatelessWidget {
+class _SlideItem extends StatelessWidget {
   final Widget slide;
-  const _Slide(this.slide);
+  const _SlideItem(this.slide);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/utils/enums.dart
+++ b/lib/utils/enums.dart
@@ -1,0 +1,1 @@
+enum IndicatorAlign { top, bottom, left, right }


### PR DESCRIPTION
With last PR https://github.com/eliezerantonio/flutter_carousel_intro/pull/20 we introduced the `scrollDirection` to define how the user can go through the onboarding `horizontal/vertical` but so far was not possible to display the slides indicator according to scrollDirection. E.g by default if `scrollDirection=Axis.horizontal` then the indicators should be displayed on page bottom/top, also if `scrollDirection=Axis.vertical` then the indicators should be displayed on page left/right side.

In this PR I added the new enum `IndicatorAlign` to define where the slides indicators should be displayed. Also included some refactoring


https://github.com/eliezerantonio/flutter_carousel_intro/assets/67912928/16ea2793-f0f4-4436-9a35-b2d7072c4c38

