### PR TITLE
Looking up a deactivated widget's ancestor is unsafe

### DIFF
--- a/lib/flutter_carousel_intro.dart
+++ b/lib/flutter_carousel_intro.dart
@@ -375,12 +375,6 @@ class _SlidesState extends State<_Slides> {
   }
 
   @override
-  void dispose() {
-    context.read<SliderModel>().pageViewController.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     final currentPage = context.watch<SliderModel>().currentPage;
     return PageView.builder(

--- a/lib/slider_model.dart
+++ b/lib/slider_model.dart
@@ -15,4 +15,10 @@ class SliderModel with ChangeNotifier {
 
     notifyListeners();
   }
+
+  @override
+  void dispose() {
+    pageViewController.dispose();
+    super.dispose();
+  }
 }


### PR DESCRIPTION
There's an opened bug issue https://github.com/eliezerantonio/flutter_carousel_intro/issues/27

It's happening because it's trying to dispose the pageViewController using the context already removed from the widget three. One of possible solution (since we want to dispose the PageViewController) is to override the dispose method inside SlideModel and dispose the PageViewController there.