### PR TITLE
Swipe the carousel to the current clicked indicator

### DIFF
--- a/lib/flutter_carousel_intro.dart
+++ b/lib/flutter_carousel_intro.dart
@@ -208,19 +208,6 @@ class _CreateStructureSlides extends StatelessWidget {
   Widget build(BuildContext context) {
     return Stack(
       children: [
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: Align(
-            alignment: _getAlignmentFromIndicatorAlign(indicatorAlign),
-            child: PageIndicator(
-              controller: context.watch<SliderModel>().pageViewController,
-              effect: getEffectFromIndicatorEffect(
-                  indicatorEffects, primaryColor, secondaryColor, 16),
-              axisDirection: scrollDirection,
-              count: slides.length,
-            ),
-          ),
-        ),
         _Slides(
           slides,
           animatedRotateX,
@@ -234,6 +221,19 @@ class _CreateStructureSlides extends StatelessWidget {
           autoPlaySlideDuration: autoPlaySlideDuration,
           autoPlaySlideDurationTransition: autoPlaySlideDurationTransition,
           autoPlaySlideDurationCurve: autoPlaySlideDurationCurve,
+        ),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Align(
+            alignment: _getAlignmentFromIndicatorAlign(indicatorAlign),
+            child: PageIndicator(
+              controller: context.watch<SliderModel>().pageViewController,
+              effect: getEffectFromIndicatorEffect(
+                  indicatorEffects, primaryColor, secondaryColor, 16),
+              axisDirection: scrollDirection,
+              count: slides.length,
+            ),
+          ),
         ),
       ],
     );

--- a/lib/page_indicator/page_indicator.dart
+++ b/lib/page_indicator/page_indicator.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_carousel_intro/page_indicator/smoth_indicator.dart';
 
 import 'effects/indicator_effect.dart';
 import 'effects/worm_effect.dart';
@@ -137,74 +138,4 @@ class _PageIndicatorState extends State<PageIndicator>
 
   @override
   TextDirection? get textDirection => widget.textDirection;
-}
-
-/// Draws dot-ish representation of pages by
-/// the number of [count] and animates the active
-/// page using [offset]
-class SmoothIndicator extends StatelessWidget {
-  /// The active page offset
-  final double offset;
-
-  /// Holds effect configuration to be used in the [BasicIndicatorPainter]
-  final IndicatorEffect effect;
-
-  /// The number of pages
-  final int count;
-
-  /// Reports dot-taps
-  final OnDotClicked? onDotClicked;
-
-  /// The size of canvas
-  final Size size;
-
-  /// The page view controller
-  final PageController controller;
-
-  /// The rotation of cans based on
-  /// text directionality and [axisDirection]
-  final int quarterTurns;
-
-  /// Default constructor
-  const SmoothIndicator({
-    Key? key,
-    required this.offset,
-    required this.count,
-    required this.size,
-    required this.controller,
-    this.quarterTurns = 0,
-    this.effect = const WormEffect(),
-    this.onDotClicked,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return RotatedBox(
-      quarterTurns: quarterTurns,
-      child: GestureDetector(
-        onTapUp: _onTap,
-        child: CustomPaint(
-          size: size,
-          // rebuild the painter with the new offset every time it updates
-          painter: effect.buildPainter(count, offset),
-        ),
-      ),
-    );
-  }
-
-  void _onTap(details) {
-    int index = effect.hitTestDots(details.localPosition.dx, count, offset);
-    if (onDotClicked != null) {
-      if (index != -1 && index != offset.toInt()) {
-        onDotClicked?.call(index);
-      }
-    } else {
-      /// Swipe the carousel to the current clicked indicator position
-      controller.animateToPage(
-        index,
-        duration: const Duration(milliseconds: 500),
-        curve: Curves.ease,
-      );
-    }
-  }
 }

--- a/lib/page_indicator/page_indicator.dart
+++ b/lib/page_indicator/page_indicator.dart
@@ -111,6 +111,7 @@ class _PageIndicatorState extends State<PageIndicator>
         onDotClicked: widget.onDotClicked,
         size: size,
         quarterTurns: quarterTurns,
+        controller: widget.controller,
       ),
     );
   }
@@ -157,6 +158,9 @@ class SmoothIndicator extends StatelessWidget {
   /// The size of canvas
   final Size size;
 
+  /// The page view controller
+  final PageController controller;
+
   /// The rotation of cans based on
   /// text directionality and [axisDirection]
   final int quarterTurns;
@@ -167,6 +171,7 @@ class SmoothIndicator extends StatelessWidget {
     required this.offset,
     required this.count,
     required this.size,
+    required this.controller,
     this.quarterTurns = 0,
     this.effect = const WormEffect(),
     this.onDotClicked,
@@ -188,11 +193,18 @@ class SmoothIndicator extends StatelessWidget {
   }
 
   void _onTap(details) {
+    int index = effect.hitTestDots(details.localPosition.dx, count, offset);
     if (onDotClicked != null) {
-      var index = effect.hitTestDots(details.localPosition.dx, count, offset);
       if (index != -1 && index != offset.toInt()) {
         onDotClicked?.call(index);
       }
+    } else {
+      /// Swipe the carousel to the current clicked indicator position
+      controller.animateToPage(
+        index,
+        duration: const Duration(milliseconds: 500),
+        curve: Curves.ease,
+      );
     }
   }
 }

--- a/lib/page_indicator/smoth_indicator.dart
+++ b/lib/page_indicator/smoth_indicator.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_carousel_intro/page_indicator/effects/indicator_effect.dart';
+import 'package:flutter_carousel_intro/page_indicator/effects/worm_effect.dart';
+import 'package:flutter_carousel_intro/page_indicator/page_indicator.dart';
+
+/// Draws dot-ish representation of pages by
+/// the number of [count] and animates the active
+/// page using [offset]
+class SmoothIndicator extends StatelessWidget {
+  /// The active page offset
+  final double offset;
+
+  /// Holds effect configuration to be used in the [BasicIndicatorPainter]
+  final IndicatorEffect effect;
+
+  /// The number of pages
+  final int count;
+
+  /// Reports dot-taps
+  final OnDotClicked? onDotClicked;
+
+  /// The size of canvas
+  final Size size;
+
+  /// The page view controller
+  final PageController controller;
+
+  /// The rotation of cans based on
+  /// text directionality and [axisDirection]
+  final int quarterTurns;
+
+  /// Default constructor
+  const SmoothIndicator({
+    Key? key,
+    required this.offset,
+    required this.count,
+    required this.size,
+    required this.controller,
+    this.quarterTurns = 0,
+    this.effect = const WormEffect(),
+    this.onDotClicked,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return RotatedBox(
+      quarterTurns: quarterTurns,
+      child: GestureDetector(
+        onTapUp: _onTap,
+        child: CustomPaint(
+          size: size,
+          // rebuild the painter with the new offset every time it updates
+          painter: effect.buildPainter(count, offset),
+        ),
+      ),
+    );
+  }
+
+  void _onTap(details) {
+    int index = effect.hitTestDots(details.localPosition.dx, count, offset);
+    if (onDotClicked != null) {
+      if (index != -1 && index != offset.toInt()) {
+        onDotClicked?.call(index);
+      }
+    } else {
+      /// Swipe the carousel to the current clicked indicator position
+      controller.animateToPage(
+        index,
+        duration: const Duration(milliseconds: 500),
+        curve: Curves.ease,
+      );
+    }
+  }
+}


### PR DESCRIPTION
This come as an implementation of a feature requested here issue https://github.com/eliezerantonio/flutter_carousel_intro/issues/29

**Before**

https://github.com/eliezerantonio/flutter_carousel_intro/assets/67912928/543a1064-460d-432e-83b5-9030e5c4a0bb


**After**


https://github.com/eliezerantonio/flutter_carousel_intro/assets/67912928/910b3915-9acd-4477-a4ff-0aed6250bbee


