### PR TITLE
Importações necessárias.

### DIFF
--- a/resources/translation/pt_pt/README.md
+++ b/resources/translation/pt_pt/README.md
@@ -116,6 +116,8 @@ animatedRotateZ: true
   ```dart
 import 'package:flutter/material.dart';
 import 'package:flutter_carousel_intro/flutter_carousel_intro.dart';
+import 'package:flutter_carousel_intro/utils/enums.dart';
+import 'package:flutter_svg/svg.dart';
 
 void main() {
   runApp(const MyApp());


### PR DESCRIPTION
@aosccode
Acabei de colocar as duas importações da "versão do código personalizado" no documento principal em portugues pra não confundir os oontribuidores e evitar erros nos valores do indicador que estão declarados no enums e para importar as imagens també  SVG
import 'package:flutter_carousel_intro/utils/enums.dart';
import 'package:flutter_svg/svg.dart';