### PR TITLE
Added Title and Subtitle to Slider with custom style

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_carousel_intro/flutter_carousel_intro.dart';
+import 'package:flutter_carousel_intro/slider_item_model.dart';
 import 'package:flutter_carousel_intro/utils/enums.dart';
 import 'package:flutter_svg/svg.dart';
 
@@ -57,11 +58,32 @@ class MySlideShow extends StatelessWidget {
         indicatorEffect: IndicatorEffects.jumping,
         showIndicators: true,
         slides: [
-          SvgPicture.asset("assets/slide-1.svg"),
-          SvgPicture.asset("assets/slide-2.svg"),
-          SvgPicture.asset("assets/slide-3.svg"),
-          SvgPicture.asset("assets/slide-4.svg"),
-          SvgPicture.asset("assets/slide-5.svg"),
+          SliderItem(
+            title: 'Title 1',
+            subtitle: 'Lorem Ipsum is simply dummy text of the printing',
+            widget: SvgPicture.asset("assets/slide-1.svg"),
+          ),
+          SliderItem(
+            title: 'Title 2',
+            subtitle: 'Lorem Ipsum is simply dummy text of the printing',
+            widget: SvgPicture.asset("assets/slide-2.svg"),
+          ),
+          SliderItem(
+            title: 'Title 3',
+            subtitle: 'Lorem Ipsum is simply dummy text of the printing',
+            widget: SvgPicture.asset("assets/slide-3.svg"),
+          ),
+          SliderItem(
+            title: 'Title 4',
+            subtitle: 'Lorem Ipsum is simply dummy text of the printing',
+            widget: SvgPicture.asset("assets/slide-4.svg"),
+          ),
+          SliderItem(
+            title: 'Title 5',
+            subtitle: 'Lorem Ipsum is simply dummy text of the printing',
+            widget: SvgPicture.asset("assets/slide-5.svg"),
+            subtitleTextStyle: Theme.of(context).textTheme.displayMedium,
+          ),
         ],
       ),
     );

--- a/lib/carousel_item.dart
+++ b/lib/carousel_item.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_carousel_intro/create_structure_slides.dart';
+import 'package:flutter_carousel_intro/slider_item_model.dart';
 import 'package:flutter_carousel_intro/slider_model.dart';
 import 'package:flutter_carousel_intro/utils/enums.dart';
 import 'package:provider/provider.dart';
@@ -21,6 +22,10 @@ class CarouselItem extends StatelessWidget {
     required this.scrollDirection,
     required this.indicatorAlign,
     required this.autoPlay,
+    required this.titleTextStyle,
+    required this.subtitleTextStyle,
+    required this.titleTextAlign,
+    required this.subtitleTextAlign,
     required this.indicatorEffects,
     required this.autoPlaySlideDuration,
     required this.autoPlaySlideDurationTransition,
@@ -30,7 +35,7 @@ class CarouselItem extends StatelessWidget {
 
   final Color primaryColor;
   final Color secondaryColor;
-  final List<Widget> slides;
+  final List<SliderItem> slides;
   final bool animatedRotateX;
   final bool animatedRotateZ;
   final bool scale;
@@ -47,6 +52,10 @@ class CarouselItem extends StatelessWidget {
   final Duration autoPlaySlideDurationTransition;
   final Curve autoPlaySlideDurationCurve;
   final bool showIndicators;
+  final TextStyle? titleTextStyle;
+  final TextStyle? subtitleTextStyle;
+  final TextAlign? titleTextAlign;
+  final TextAlign? subtitleTextAlign;
 
   @override
   Widget build(BuildContext context) {
@@ -70,6 +79,10 @@ class CarouselItem extends StatelessWidget {
           scrollDirection: scrollDirection,
           indicatorAlign: indicatorAlign,
           autoPlay: autoPlay,
+          titleTextStyle: titleTextStyle,
+          titleTextAlign: titleTextAlign,
+          subtitleTextStyle: subtitleTextStyle,
+          subtitleTextAlign: subtitleTextAlign,
           autoPlaySlideDuration: autoPlaySlideDuration,
           indicatorEffects: indicatorEffects,
           primaryColor: primaryColor,

--- a/lib/carousel_slide_item.dart
+++ b/lib/carousel_slide_item.dart
@@ -1,14 +1,74 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_carousel_intro/slider_item_model.dart';
 
 class CarouselSlideItem extends StatelessWidget {
-  final Widget slide;
-  const CarouselSlideItem(this.slide, {super.key});
+  final SliderItem slide;
+  final TextStyle? titleTextStyle;
+  final TextStyle? subtitleTextStyle;
+  final TextAlign? titleTextAlign;
+  final TextAlign? subtitleTextAlign;
+
+  const CarouselSlideItem({
+    super.key,
+    required this.slide,
+    required this.titleTextStyle,
+    required this.subtitleTextStyle,
+    required this.titleTextAlign,
+    required this.subtitleTextAlign,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.all(30),
-      child: slide,
+      child: Column(
+        children: [
+          SizedBox(
+            height: _getSlideWidgetHeight(context, slide.title, slide.subtitle),
+            child: slide.widget,
+          ),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                if (slide.title != null)
+                  Text(
+                    slide.title ?? '',
+                    style: titleTextStyle ??
+                        slide.titleTextStyle ??
+                        Theme.of(context).textTheme.titleLarge,
+                    textAlign: titleTextAlign ??
+                        slide.titleTextAlign ??
+                        TextAlign.center,
+                  ),
+                if (slide.subtitle != null)
+                  Expanded(
+                    child: Text(
+                      slide.subtitle ?? '',
+                      style: subtitleTextStyle ??
+                          slide.subtitleTextStyle ??
+                          Theme.of(context).textTheme.titleMedium,
+                      textAlign: subtitleTextAlign ??
+                          slide.subtitleTextAlign ??
+                          TextAlign.center,
+                    ),
+                  ),
+              ],
+            ),
+          )
+        ],
+      ),
     );
+  }
+
+  double? _getSlideWidgetHeight(
+    BuildContext context,
+    String? title,
+    String? subtitle,
+  ) {
+    if (title == null && subtitle == null) {
+      return MediaQuery.sizeOf(context).height * 0.8;
+    }
+    return MediaQuery.sizeOf(context).height * 0.6;
   }
 }

--- a/lib/carousel_slides.dart
+++ b/lib/carousel_slides.dart
@@ -1,14 +1,13 @@
 import 'dart:async';
 import 'dart:math';
-
 import 'package:flutter/material.dart';
+import 'package:flutter_carousel_intro/slider_item_model.dart';
 import 'package:provider/provider.dart';
-
 import 'carousel_slide_item.dart';
 import 'slider_model.dart';
 
 class CarouselSlides extends StatefulWidget {
-  final List<Widget> slides;
+  final List<SliderItem> slides;
   final bool animatedRotateX;
   final bool animatedRotateZ;
   final bool animatedOpacity;
@@ -20,6 +19,10 @@ class CarouselSlides extends StatefulWidget {
   final Duration autoPlaySlideDuration;
   final Duration autoPlaySlideDurationTransition;
   final Curve autoPlaySlideDurationCurve;
+  final TextStyle? titleTextStyle;
+  final TextStyle? subtitleTextStyle;
+  final TextAlign? titleTextAlign;
+  final TextAlign? subtitleTextAlign;
 
   const CarouselSlides(
     this.slides,
@@ -30,6 +33,10 @@ class CarouselSlides extends StatefulWidget {
     this.physics,
     this.pageViewController, {
     super.key,
+    required this.titleTextStyle,
+    required this.subtitleTextStyle,
+    required this.titleTextAlign,
+    required this.subtitleTextAlign,
     required this.scrollDirection,
     required this.autoPlay,
     required this.autoPlaySlideDuration,
@@ -103,7 +110,11 @@ class CarouselSlidesState extends State<CarouselSlides> {
                 ..rotateZ(widget.animatedRotateZ ? pi * (value - 1) : 0.0)
                 ..scale(widget.scale ? value : 1.0, widget.scale ? value : 1.0),
               child: CarouselSlideItem(
-                widget.slides[index],
+                slide: widget.slides[index],
+                titleTextStyle: widget.titleTextStyle,
+                titleTextAlign: widget.titleTextAlign,
+                subtitleTextStyle: widget.subtitleTextStyle,
+                subtitleTextAlign: widget.subtitleTextAlign,
               ),
             ),
           ),

--- a/lib/create_structure_slides.dart
+++ b/lib/create_structure_slides.dart
@@ -9,6 +9,7 @@ import 'package:flutter_carousel_intro/page_indicator/effects/slide_effect.dart'
 import 'package:flutter_carousel_intro/page_indicator/effects/swap_effect.dart';
 import 'package:flutter_carousel_intro/page_indicator/effects/worm_effect.dart';
 import 'package:flutter_carousel_intro/page_indicator/page_indicator.dart';
+import 'package:flutter_carousel_intro/slider_item_model.dart';
 import 'package:flutter_carousel_intro/slider_model.dart';
 import 'package:flutter_carousel_intro/utils/enums.dart';
 import 'package:provider/provider.dart';
@@ -37,9 +38,13 @@ class CreateStructureSlides extends StatelessWidget {
     required this.autoPlaySlideDurationTransition,
     required this.autoPlaySlideDurationCurve,
     required this.showIndicators,
+    required this.titleTextStyle,
+    required this.subtitleTextStyle,
+    required this.titleTextAlign,
+    required this.subtitleTextAlign,
   });
 
-  final List<Widget> slides;
+  final List<SliderItem> slides;
   final bool animatedRotateX;
   final bool animatedRotateZ;
   final bool scale;
@@ -58,6 +63,10 @@ class CreateStructureSlides extends StatelessWidget {
   final Duration autoPlaySlideDurationTransition;
   final Curve autoPlaySlideDurationCurve;
   final bool showIndicators;
+  final TextStyle? titleTextStyle;
+  final TextStyle? subtitleTextStyle;
+  final TextAlign? titleTextAlign;
+  final TextAlign? subtitleTextAlign;
 
   @override
   Widget build(BuildContext context) {
@@ -73,6 +82,10 @@ class CreateStructureSlides extends StatelessWidget {
           pageViewController,
           scrollDirection: scrollDirection,
           autoPlay: autoPlay,
+          titleTextStyle: titleTextStyle,
+          titleTextAlign: titleTextAlign,
+          subtitleTextStyle: subtitleTextStyle,
+          subtitleTextAlign: subtitleTextAlign,
           autoPlaySlideDuration: autoPlaySlideDuration,
           autoPlaySlideDurationTransition: autoPlaySlideDurationTransition,
           autoPlaySlideDurationCurve: autoPlaySlideDurationCurve,

--- a/lib/flutter_carousel_intro.dart
+++ b/lib/flutter_carousel_intro.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_carousel_intro/carousel_item.dart';
 import 'package:flutter_carousel_intro/page_indicator/page_indicator.dart';
+import 'package:flutter_carousel_intro/slider_item_model.dart';
 import 'package:flutter_carousel_intro/utils/enums.dart';
 import 'package:provider/provider.dart';
 import 'slider_model.dart';
 
 class FlutterCarouselIntro extends StatelessWidget {
   //* Slide list
-  final List<Widget> slides;
+  final List<SliderItem> slides;
   final bool animatedRotateX;
   final bool animatedRotateZ;
   final bool animatedOpacity;
@@ -27,6 +28,10 @@ class FlutterCarouselIntro extends StatelessWidget {
   final Duration? autoPlaySlideDurationTransition;
   final Curve? autoPlaySlideDurationCurve;
   final bool showIndicators;
+  final TextStyle? titleTextStyle;
+  final TextAlign? titleTextAlign;
+  final TextAlign? subtitleTextAlign;
+  final TextStyle? subtitleTextStyle;
 
   const FlutterCarouselIntro({
     Key? key,
@@ -43,10 +48,14 @@ class FlutterCarouselIntro extends StatelessWidget {
     this.dotsContainerHeight,
     this.dotsContainerWidth,
     this.controller,
+    this.titleTextStyle,
+    this.subtitleTextStyle,
     this.scrollDirection = Axis.horizontal,
     this.indicatorAlign,
     this.pageIndicator,
     this.indicatorEffect,
+    this.titleTextAlign,
+    this.subtitleTextAlign,
     this.autoPlaySlideDurationTransition,
     this.autoPlaySlideDurationCurve,
     this.showIndicators = true,
@@ -70,6 +79,10 @@ class FlutterCarouselIntro extends StatelessWidget {
         controller: controller,
         scrollDirection: scrollDirection,
         indicatorAlign: indicatorAlign,
+        titleTextStyle: titleTextStyle,
+        titleTextAlign: titleTextAlign,
+        subtitleTextStyle: subtitleTextStyle,
+        subtitleTextAlign: subtitleTextAlign,
         autoPlay: autoPlay,
         autoPlaySlideDurationCurve: autoPlaySlideDurationCurve ?? Curves.ease,
         autoPlaySlideDurationTransition: autoPlaySlideDurationTransition ??

--- a/lib/slider_item_model.dart
+++ b/lib/slider_item_model.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+/// A model to represent each Slide item
+///
+/// e.g
+///
+/// ```dart
+/// SlideItem(title: '', subtitle: '', widget: Image.asset())
+///
+/// ```
+class SliderItem {
+  /// **[widget]** the required slide widget
+  final Widget widget;
+
+  /// [title] optional slide title
+  final String? title;
+
+  /// [titleTextStyle] optional title TextStyle, if set it override the
+  /// /// top-level title textStyle
+  final TextStyle? titleTextStyle;
+
+  ///  [titleTextAlign] optional title TextAlign, if set it override the
+  /// top-level title textAlign
+  final TextAlign? titleTextAlign;
+
+  /// [subtitle] optional slide subtile
+  final String? subtitle;
+
+  ///  [subtitle] optional subtitle TextStyle, if set it override the
+  /// top-level subtitle textStyle
+  final TextStyle? subtitleTextStyle;
+
+  ///  [subtitleTextAlign] optional subtitle TextAlign, if set it override the
+  /// top-level subtitle textAlign
+  final TextAlign? subtitleTextAlign;
+
+  const SliderItem({
+    this.title,
+    this.titleTextStyle,
+    this.titleTextAlign,
+    this.subtitle,
+    this.subtitleTextStyle,
+    this.subtitleTextAlign,
+    required this.widget,
+  });
+}


### PR DESCRIPTION
Currently our Slide just support a List of widgets, would be great to have a `SliderItem` model to hold each Slide List item and it can contains a title, subtitle (both of them optional) and a widget (which can represent an image).

In this PR I implemented this feature. I added a `SliderModel`, it contains a `required` field `widget`,  an optional `tittle`, `subtitle`, `TextStyle` for title and subtitle, also a `TextAlign` for title and subtitle. Those styles `TextStyle` and `TextAlign` represent the style of that specific Slider item. We can set a top-level TextStyle or TextAlign.


https://github.com/eliezerantonio/flutter_carousel_intro/assets/67912928/aa3a341c-125c-4c42-a076-571e3e09b2e9


